### PR TITLE
Fix JSON formatter newline

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -110,9 +110,9 @@ func (f *JSONFormatter) Format(level LogLevel, message string) string {
 	}
 	jsonLog, err := json.Marshal(logEntry)
 	if err != nil {
-		return fmt.Sprintf(`{"error": "failed to format log message", "message": "%s"}`, message)
+		return fmt.Sprintf(`{"error": "failed to format log message", "message": "%s"}\n`, message)
 	}
-	return string(jsonLog)
+	return string(jsonLog) + "\n"
 }
 
 // log logs a message using the current formatter


### PR DESCRIPTION
## Summary
- ensure JSON log lines are newline terminated

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_683a5469961083308c01ef81d19b6328