### PR TITLE
Fix custom formatter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ func main() {
 type MyCustomFormatter struct{}
 
 func (f *MyCustomFormatter) Format(level log.LogLevel, message string) string {
-	return fmt.Sprintf("**CUSTOM LOG** [%s] %s
-", logLevelToString(level), message)
+	return fmt.Sprintf("**CUSTOM LOG** [%s] %s\n", logLevelToString(level), message)
 }
 
 func logLevelToString(level log.LogLevel) string {


### PR DESCRIPTION
## Summary
- fix custom formatter `fmt.Sprintf` example in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_683a55e8a49083308a4c7194607bce60