### PR TITLE
Fix README example for proper fatal logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ func main() {
 	// Open a file for logging
 	file, err := os.OpenFile("app.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Fatal("Failed to open log file")
+		logger.Fatal("Failed to open log file")
 	}
 	defer file.Close()
 


### PR DESCRIPTION
## Summary
- correct README documentation for using `logger.Fatal`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_683a55ed911c8330b9b1e8226e81d0b6