### PR TITLE
Add unit tests for configuration and logger

### DIFF
--- a/config_internal_test.go
+++ b/config_internal_test.go
@@ -1,0 +1,22 @@
+package log
+
+import "testing"
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected LogLevel
+	}{
+		{"DEBUG", DEBUG},
+		{"info", INFO},
+		{"Warn", WARN},
+		{"error", ERROR},
+		{"fatal", FATAL},
+		{"unknown", INFO},
+	}
+	for _, tt := range tests {
+		if got := parseLogLevel(tt.in); got != tt.expected {
+			t.Errorf("parseLogLevel(%s)=%v, want %v", tt.in, got, tt.expected)
+		}
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,146 @@
+package log_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	log "github.com/pod32g/simple-logger"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := log.DefaultConfig()
+	if cfg.Level != log.INFO {
+		t.Errorf("expected level INFO, got %v", cfg.Level)
+	}
+	if cfg.Output != "stdout" {
+		t.Errorf("expected output stdout, got %s", cfg.Output)
+	}
+	if cfg.Format != "text" {
+		t.Errorf("expected format text, got %s", cfg.Format)
+	}
+	if !cfg.EnableCaller {
+		t.Errorf("expected EnableCaller true")
+	}
+}
+
+func TestLoadConfigFromEnv(t *testing.T) {
+	os.Setenv("LOG_LEVEL", "DEBUG")
+	os.Setenv("LOG_OUTPUT", "stderr")
+	os.Setenv("LOG_FORMAT", "json")
+	os.Setenv("LOG_ENABLE_CALLER", "false")
+	defer os.Unsetenv("LOG_LEVEL")
+	defer os.Unsetenv("LOG_OUTPUT")
+	defer os.Unsetenv("LOG_FORMAT")
+	defer os.Unsetenv("LOG_ENABLE_CALLER")
+
+	cfg := log.LoadConfigFromEnv()
+	if cfg.Level != log.DEBUG {
+		t.Errorf("expected level DEBUG, got %v", cfg.Level)
+	}
+	if cfg.Output != "stderr" {
+		t.Errorf("expected output stderr, got %s", cfg.Output)
+	}
+	if cfg.Format != "json" {
+		t.Errorf("expected format json, got %s", cfg.Format)
+	}
+	if cfg.EnableCaller {
+		t.Errorf("expected EnableCaller false")
+	}
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "cfg.json")
+	data := []byte(`{"level":3,"output":"stdout","format":"json","enable_caller":false}`)
+	if err := os.WriteFile(file, data, 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	cfg, err := log.LoadConfigFromFile(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Level != log.ERROR {
+		t.Errorf("expected level ERROR, got %v", cfg.Level)
+	}
+	if cfg.Output != "stdout" {
+		t.Errorf("expected output stdout, got %s", cfg.Output)
+	}
+	if cfg.Format != "json" {
+		t.Errorf("expected format json, got %s", cfg.Format)
+	}
+	if cfg.EnableCaller {
+		t.Errorf("expected EnableCaller false")
+	}
+}
+
+func TestUpdateLogLevelAndFormat(t *testing.T) {
+	cfg := log.DefaultConfig()
+	cfg.UpdateLogLevel(log.DEBUG)
+	cfg.UpdateLogFormat("json")
+	if cfg.Level != log.DEBUG {
+		t.Errorf("expected level DEBUG, got %v", cfg.Level)
+	}
+	if cfg.Format != "json" {
+		t.Errorf("expected format json, got %s", cfg.Format)
+	}
+}
+
+func TestApplyConfigText(t *testing.T) {
+	cfg := log.DefaultConfig()
+	logger := log.ApplyConfig(cfg)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.Info("hello")
+	if !containsLogMessage(buf.String(), "INFO", "hello") {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
+func TestApplyConfigJSON(t *testing.T) {
+	cfg := log.DefaultConfig()
+	cfg.Format = "json"
+	logger := log.ApplyConfig(cfg)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.Info("hello")
+	if !isValidJSON(buf.String()) {
+		t.Errorf("expected JSON output, got %s", buf.String())
+	}
+}
+
+func TestApplyConfigCustomFormatter(t *testing.T) {
+	cfg := log.DefaultConfig()
+	cfg.Format = "custom"
+	cfg.Custom = &testFormatter{}
+	logger := log.ApplyConfig(cfg)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.Info("msg")
+	if buf.String() != "CUSTOM(INFO) msg\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
+type testFormatter struct{}
+
+func (testFormatter) Format(level log.LogLevel, message string) string {
+	return "CUSTOM(" + logLevelToString(level) + ") " + message + "\n"
+}
+
+func TestApplyConfigFileOutput(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "log.txt")
+	cfg := log.DefaultConfig()
+	cfg.Output = file
+	logger := log.ApplyConfig(cfg)
+	logger.Info("file message")
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("unable to read file: %v", err)
+	}
+	if !bytes.Contains(data, []byte("file message")) {
+		t.Errorf("expected message in file, got %s", string(data))
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -108,6 +108,32 @@ func TestLogger_CustomFormatter(t *testing.T) {
 	}
 }
 
+// TestLogger_SetOutput verifies that changing the output writer works
+func TestLogger_SetOutput(t *testing.T) {
+	var buf1 bytes.Buffer
+	var buf2 bytes.Buffer
+	logger := log.NewLogger(&buf1, log.INFO, &log.DefaultFormatter{})
+	logger.SetOutput(&buf2)
+	logger.Info("changed")
+	if buf1.Len() != 0 {
+		t.Errorf("expected no output on original writer, got %v", buf1.String())
+	}
+	if buf2.Len() == 0 {
+		t.Errorf("expected output on new writer")
+	}
+}
+
+// TestLogger_SetFormatter verifies that changing the formatter changes output format
+func TestLogger_SetFormatter(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.NewLogger(&buf, log.INFO, &log.DefaultFormatter{})
+	logger.SetFormatter(&log.JSONFormatter{})
+	logger.Info("json msg")
+	if !isValidJSON(buf.String()) {
+		t.Errorf("expected JSON formatted message, got %v", buf.String())
+	}
+}
+
 // MyCustomFormatter is a test custom formatter
 type MyCustomFormatter struct{}
 


### PR DESCRIPTION
## Summary
- test DefaultConfig values and environment/file loading
- cover runtime updates and ApplyConfig behaviour
- verify parseLogLevel
- add logger tests for SetOutput and SetFormatter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_683a55c950dc8330a9fe41f0a7fbbbe8