### PR TITLE
Fix newline handling in JSON formatter

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -110,7 +110,7 @@ func (f *JSONFormatter) Format(level LogLevel, message string) string {
 	}
 	jsonLog, err := json.Marshal(logEntry)
 	if err != nil {
-		return fmt.Sprintf(`{"error": "failed to format log message", "message": "%s"}\n`, message)
+		jsonLog = []byte(fmt.Sprintf(`{"error": "failed to format log message", "message": "%s"}`, message))
 	}
 	return string(jsonLog) + "\n"
 }


### PR DESCRIPTION
## Summary
- ensure JSONFormatter appends a newline after marshaling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_683a560167c0833080da0ffc949cc233