### PR TITLE
Fix logger tests and resolve duplicate test name

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -131,10 +131,12 @@ func TestLogger_SetFormatter(t *testing.T) {
 	logger.Info("json msg")
 	if !isValidJSON(buf.String()) {
 		t.Errorf("expected JSON formatted message, got %v", buf.String())
-    
-// TestLoadConfigFromEnv verifies that configuration is correctly loaded from
-// environment variables
-func TestLoadConfigFromEnv(t *testing.T) {
+	}
+}
+
+// TestLoggerLoadConfigFromEnv verifies that configuration is correctly loaded from
+// environment variables for logger tests
+func TestLoggerLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "DEBUG")
 	t.Setenv("LOG_OUTPUT", "stderr")
 	t.Setenv("LOG_FORMAT", "JSON")


### PR DESCRIPTION
## Summary
- fix missing braces in `logger_test.go`
- rename duplicate `TestLoadConfigFromEnv` to `TestLoggerLoadConfigFromEnv`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_683a5767330c83308ff905dc8486da54