### PR TITLE
Add logger benchmark and document results

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ func logLevelToString(level log.LogLevel) string {
 }
 ```
 
+## Benchmarks
+
+The following simple benchmark compares the logger performance with `fmt.Sprintf`.
+
+```bash
+$ go test -bench .
+BenchmarkLoggerDefault-5          371880        2898 ns/op
+BenchmarkFmtSprintf-5            5556867         209.7 ns/op
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,22 @@
+package log_test
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	log "github.com/pod32g/simple-logger"
+)
+
+func BenchmarkLoggerDefault(b *testing.B) {
+	logger := log.NewLogger(io.Discard, log.INFO, &log.DefaultFormatter{})
+	for i := 0; i < b.N; i++ {
+		logger.Info("benchmark message", i)
+	}
+}
+
+func BenchmarkFmtSprintf(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = fmt.Sprintf("benchmark message %d", i)
+	}
+}


### PR DESCRIPTION
## Summary
- add benchmark comparing logger performance to fmt.Sprintf
- mention benchmark results in README

## Testing
- `go test ./...`
- `go test -bench=. ./...`


------
https://chatgpt.com/codex/tasks/task_b_683e15ccc2688330a863ac97ad1d4d6d