### PR TITLE
Add GitHub Pages site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+remote_theme: pages-themes/slate@v0.2.0
+plugins:
+- jekyll-remote-theme

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Simple Logger
+---
+
+# Simple Logger
+
+Simple Logger is a lightweight logging library for Go that supports multiple log levels, customizable formats, and dynamic configuration.
+
+## Features
+
+- **Multiple Log Levels**: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`.
+- **Configurable Outputs**: direct logs to `stdout`, `stderr`, or a file.
+- **Flexible Formatting**: choose between plain text, JSON, or provide your own custom formatter.
+- **Runtime Configuration**: adjust log levels and formats without restarting your application.
+- **Simple API**: quickly integrate logging into any Go project.
+
+## Advantages
+
+- Minimal setup with sensible defaults.
+- Tunable performance: disable caller lookup when you need speed.
+- MIT licensed and open for contributions.
+- Works anywhere Go runs.
+
+## Getting Started
+
+Install the package:
+
+```bash
+go get github.com/pod32g/simple-logger
+```
+
+See the [README](../README.md) for detailed usage examples and benchmark results.
+
+---
+Happy logging!


### PR DESCRIPTION
## Summary
- create `docs` folder for GitHub Pages
- document project features and advantages on `docs/index.md`
- configure the site using the Slate theme

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_683e207652d88330b73653a42351de37