### PR TITLE
Update and expand examples

### DIFF
--- a/example/buffer_output/main.go
+++ b/example/buffer_output/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	log "github.com/pod32g/simple-logger"
+)
+
+func main() {
+	logger := log.ApplyConfig(log.DefaultConfig())
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.Info("first message written to buffer")
+
+	logger.SetLevel(log.DEBUG)
+	logger.SetFormatter(&log.JSONFormatter{})
+	logger.Debug("second message as JSON")
+
+	fmt.Print(buf.String())
+}

--- a/example/custom_args/main.go
+++ b/example/custom_args/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	log "github.com/pod32g/simple-logger"
+)
+
+func main() {
+	cfg := log.DefaultConfig()
+	cfg.Format = "custom"
+	cfg.Custom = &SimpleStreamingFormatter{}
+
+	logger := log.ApplyConfig(cfg)
+
+	logger.Info("User", 7, "performed action")
+}
+
+// SimpleStreamingFormatter implements ArgsFormatter for demonstration
+type SimpleStreamingFormatter struct{}
+
+func (f *SimpleStreamingFormatter) Format(level log.LogLevel, message string) string {
+	var b strings.Builder
+	f.FormatArgs(level, &b, message)
+	return b.String()
+}
+
+func (f *SimpleStreamingFormatter) FormatArgs(level log.LogLevel, w io.Writer, v ...interface{}) {
+	fmt.Fprintf(w, "%s [%s] ", time.Now().Format("2006-01-02 15:04:05"), levelToString(level))
+	for i, val := range v {
+		if i > 0 {
+			fmt.Fprint(w, " ")
+		}
+		fmt.Fprint(w, val)
+	}
+	fmt.Fprint(w, "\n")
+}
+
+func levelToString(level log.LogLevel) string {
+	switch level {
+	case log.DEBUG:
+		return "DEBUG"
+	case log.INFO:
+		return "INFO"
+	case log.WARN:
+		return "WARN"
+	case log.ERROR:
+		return "ERROR"
+	case log.FATAL:
+		return "FATAL"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/example/dynamic_format/main.go
+++ b/example/dynamic_format/main.go
@@ -1,0 +1,13 @@
+package main
+
+import log "github.com/pod32g/simple-logger"
+
+func main() {
+	cfg := log.DefaultConfig()
+	logger := log.ApplyConfig(cfg)
+	logger.Info("This is printed in text format")
+
+	cfg.UpdateLogFormat("json")
+	logger = log.ApplyConfig(cfg)
+	logger.Info("This is printed in JSON format")
+}

--- a/example/main.go
+++ b/example/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
+	"time"
 
 	log "github.com/pod32g/simple-logger"
 )
@@ -132,6 +135,26 @@ func main() {
 	// Log some messages with the custom formatter
 	logger.Info("Example 7: This is a custom formatted info message")
 	logger.Debug("Example 7: This is a custom formatted debug message")
+
+	// Example 8: Updating the Log Format at Runtime
+	// --------------------------------------------
+	// Start with the default text format
+	config = log.DefaultConfig()
+	logger = log.ApplyConfig(config)
+	logger.Info("Example 8: this message uses text format")
+
+	// Change to JSON without restarting the application
+	config.UpdateLogFormat("json")
+	logger = log.ApplyConfig(config)
+	logger.Info("Example 8: this message uses JSON format")
+
+	// Example 9: Custom ArgsFormatter for Efficient Logging
+	// -----------------------------------------------------
+	config = log.DefaultConfig()
+	config.Format = "custom"
+	config.Custom = &StreamingFormatter{}
+	logger = log.ApplyConfig(config)
+	logger.Info("Example 9:", "user", 42, "logged in")
 }
 
 // MyCustomFormatter is a sample custom formatter for demonstration
@@ -156,4 +179,24 @@ func logLevelToString(level log.LogLevel) string {
 	default:
 		return "UNKNOWN"
 	}
+}
+
+// StreamingFormatter demonstrates implementing ArgsFormatter for high-performance logging
+type StreamingFormatter struct{}
+
+func (f *StreamingFormatter) Format(level log.LogLevel, message string) string {
+	var sb strings.Builder
+	f.FormatArgs(level, &sb, message)
+	return sb.String()
+}
+
+func (f *StreamingFormatter) FormatArgs(level log.LogLevel, w io.Writer, v ...interface{}) {
+	fmt.Fprintf(w, "%s [%s] ", time.Now().Format("2006-01-02 15:04:05"), logLevelToString(level))
+	for i, val := range v {
+		if i > 0 {
+			fmt.Fprint(w, " ")
+		}
+		fmt.Fprint(w, val)
+	}
+	fmt.Fprint(w, "\n")
 }


### PR DESCRIPTION
## Summary
- extend main example with runtime format change and streaming formatter
- add dynamic format example
- add custom args formatting example
- add buffer output example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_683f7bb4d09c83308b5e70f506fa5404